### PR TITLE
Button-Mistake

### DIFF
--- a/module/EcampWeb/view/ecamp-web/auth/login/login.twig
+++ b/module/EcampWeb/view/ecamp-web/auth/login/login.twig
@@ -111,7 +111,7 @@
                             type="button"
                             class="btn-link"
                             href="{{ url('web/default', { 'controller': 'register', 'action': 'forgot-password' }) }}"
-                        >Forgot password</a>
+                        >Forgot password</button>
                         &nbsp;&nbsp;|&nbsp;&nbsp;
                         <button
                             async-modal


### PR DESCRIPTION
The button didn't got closed. Instead an non-existent "a" got closed.